### PR TITLE
use consistent nvflare version for MediSwarm

### DIFF
--- a/nvflare/lighter/impl/cert.py
+++ b/nvflare/lighter/impl/cert.py
@@ -116,11 +116,11 @@ class CertBuilder(Builder):
             with open(os.path.join(dest_dir, "server.key"), "wb") as f:
                 f.write(serialize_pri_key(tmp_pri_key))
 
-        pkcs12 = serialization.pkcs12.serialize_key_and_certificates(
-            subject.encode("ascii"), pri_key, cert, None, serialization.BestAvailableEncryption(subject.encode("ascii"))
-        )
-        with open(os.path.join(dest_dir, f"{base_name}.pfx"), "wb") as f:
-            f.write(pkcs12)
+        # pkcs12 = serialization.pkcs12.serialize_key_and_certificates(
+        #     subject.encode("ascii"), pri_key, cert, None, serialization.BestAvailableEncryption(subject.encode("ascii"))
+        # )
+        # with open(os.path.join(dest_dir, f"{base_name}.pfx"), "wb") as f:
+        #     f.write(pkcs12)
         with open(os.path.join(dest_dir, "rootCA.pem"), "wb") as f:
             f.write(self.serialized_cert)
 

--- a/nvflare/lighter/impl/workspace.py
+++ b/nvflare/lighter/impl/workspace.py
@@ -64,6 +64,7 @@ class WorkspaceBuilder(Builder):
         template_file_full_path = os.path.join(self.get_resources_dir(ctx), self.template_file)
         file_path = pathlib.Path(__file__).parent.absolute()
         if os.path.join(file_path, self.template_file) != template_file_full_path:
+            # do not copy if source and target are identical
             shutil.copyfile(os.path.join(file_path, self.template_file), template_file_full_path)
         ctx["template_file"] = self.template_file
 

--- a/nvflare/lighter/impl/workspace.py
+++ b/nvflare/lighter/impl/workspace.py
@@ -63,7 +63,8 @@ class WorkspaceBuilder(Builder):
         ctx["last_prod_stage"] = last
         template_file_full_path = os.path.join(self.get_resources_dir(ctx), self.template_file)
         file_path = pathlib.Path(__file__).parent.absolute()
-        shutil.copyfile(os.path.join(file_path, self.template_file), template_file_full_path)
+        if os.path.join(file_path, self.template_file) != template_file_full_path:
+            shutil.copyfile(os.path.join(file_path, self.template_file), template_file_full_path)
         ctx["template_file"] = self.template_file
 
     def build(self, project: Project, ctx: dict):


### PR DESCRIPTION
* Workarounds for being able to build startup kits from project-….yml files in our current setup
* see https://github.com/KatherLab/MediSwarm/issues/27
* needed for https://github.com/KatherLab/MediSwarm/pull/28