### PR TITLE
Support KEY=VALUE env var prefixes in SubprocessLauncher script

### DIFF
--- a/nvflare/app_common/launchers/subprocess_launcher.py
+++ b/nvflare/app_common/launchers/subprocess_launcher.py
@@ -181,6 +181,12 @@ class SubprocessLauncher(Launcher):
                 add_custom_dir_to_path(app_custom_folder, env)
 
                 command_seq = shlex.split(command)
+                # Allow shell-style "KEY=VALUE ... prog args" prefixes in script: strip
+                # leading KEY=VALUE tokens and merge into env, since subprocess.Popen
+                # without shell=True won't interpret them as env assignments.
+                while command_seq and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", command_seq[0]):
+                    key, _, value = command_seq.pop(0).partition("=")
+                    env[key] = value
                 self._process = subprocess.Popen(
                     command_seq, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=self._app_dir, env=env
                 )


### PR DESCRIPTION
## Summary

- Fixes `FileNotFoundError: [Errno 2] No such file or directory: 'MODEL_NAME=<value>'` when starting challenge jobs (`challenge_1DivideAndConquer`, `challenge_2BCN_AIM`, `challenge_3agaldran`, `challenge_4abmil`, `challenge_5pimed`) via `SubprocessLauncher`.
- Root cause: `_start_external_process` ran `shlex.split(script)` then `subprocess.Popen(..., shell=False)`, so a leading shell-style `KEY=VALUE` token (e.g. `"MODEL_NAME=1DivideAndConquer python3 custom/..."`) was exec'd as a program name instead of being interpreted as an env assignment.
- Fix: strip leading `KEY=VALUE` tokens from the split command and merge them into the `env` dict passed to `Popen`, matching shell semantics. Scripts without such prefixes are unaffected.

## Failing log (reported by users)

```
PTClientAPILauncherExecutor - WARNING - [identity=RSH_1, run=...] - launcher method (initialize) execution failed: FileNotFoundError: [Errno 2] No such file or directory: 'MODEL_NAME=1DivideAndConquer'
```

## Test plan

- [ ] On a 2-client swarm, `submit_job application/jobs/minimal_training_pytorch_cnn` still succeeds (regression).
- [ ] `submit_job application/jobs/ODELIA_ternary_classification` still starts training (`mst | _MST` in logs).
- [ ] `submit_job application/jobs/challenge_1DivideAndConquer` passes `initialize` and the subprocess sees `MODEL_NAME=1DivideAndConquer`.
- [ ] Spot-check one other `challenge_*` job (e.g. `challenge_2BCN_AIM`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)