### PR TITLE
ccwf: separate configure quorum from runtime min_clients tolerance

### DIFF
--- a/nvflare/app_common/ccwf/server_ctl.py
+++ b/nvflare/app_common/ccwf/server_ctl.py
@@ -75,6 +75,7 @@ class ServerSideController(Controller):
         progress_timeout: float = Constant.WORKFLOW_PROGRESS_TIMEOUT,
         private_p2p: bool = True,
         min_clients: int = 0,
+        configure_min_clients: int = 0,
     ):
         """
         Constructor
@@ -117,6 +118,11 @@ class ServerSideController(Controller):
                 0 means all participating clients are required (default, backward compatible).
                 N > 0 means the workflow proceeds as long as at least N clients are active;
                 the job only aborts when active clients drop below this threshold.
+            configure_min_clients - minimum number of clients required to complete workflow configuration before
+                the workflow can start.
+                0 means use min_clients for configuration (backward compatible).
+                Set this higher than min_clients when every client must receive the initial model before runtime
+                drop tolerance is enabled.
             private_p2p - whether to make peer-to-peer communications private.
                 When set to True, P2P communications will be encrypted.
                 Private P2P communication is an additional level of protection on basic communication security
@@ -161,6 +167,9 @@ class ServerSideController(Controller):
         if min_clients < 0:
             raise ValueError(f"min_clients must be >= 0, but got {min_clients}")
         self.min_clients = min_clients
+        if configure_min_clients < 0:
+            raise ValueError(f"configure_min_clients must be >= 0, but got {configure_min_clients}")
+        self.configure_min_clients = configure_min_clients
 
         check_positive_int("num_rounds", num_rounds)
         check_number_range("configure_task_timeout", configure_task_timeout, min_value=1)
@@ -199,6 +208,11 @@ class ServerSideController(Controller):
         if self.min_clients > 0 and self.min_clients > num_participating:
             raise RuntimeError(
                 f"min_clients ({self.min_clients}) exceeds the number of participating clients "
+                f"({num_participating}): {self.participating_clients}"
+            )
+        if self.configure_min_clients > 0 and self.configure_min_clients > num_participating:
+            raise RuntimeError(
+                f"configure_min_clients ({self.configure_min_clients}) exceeds the number of participating clients "
                 f"({num_participating}): {self.participating_clients}"
             )
 
@@ -264,7 +278,20 @@ class ServerSideController(Controller):
         )
 
         total_clients = len(self.participating_clients)
-        required = self.min_clients if self.min_clients > 0 else total_clients
+        required = (
+            self.configure_min_clients
+            if self.configure_min_clients > 0
+            else self.min_clients
+            if self.min_clients > 0
+            else total_clients
+        )
+        required_label = (
+            f"configure_min_clients={self.configure_min_clients}"
+            if self.configure_min_clients > 0
+            else f"min_clients={self.min_clients}"
+            if self.min_clients > 0
+            else "all participating clients"
+        )
         self.log_info(fl_ctx, f"sending task {self.configure_task_name} to clients {self.participating_clients}")
         start_time = time.time()
         self.broadcast_and_wait(
@@ -282,7 +309,8 @@ class ServerSideController(Controller):
         configured_count = total_clients - len(failed_clients)
         if configured_count < required:
             self.system_panic(
-                f"failed to configure clients {failed_clients}: only {configured_count}/{total_clients} configured, need {required}",
+                f"failed to configure clients {failed_clients}: only {configured_count}/{total_clients} configured, "
+                f"need {required} (configure_min_clients={self.configure_min_clients}, min_clients={self.min_clients})",
                 fl_ctx,
             )
             return
@@ -290,7 +318,7 @@ class ServerSideController(Controller):
         if failed_clients:
             self.log_warning(
                 fl_ctx,
-                f"clients {failed_clients} did not configure within timeout but min_clients={self.min_clients} "
+                f"clients {failed_clients} did not configure within timeout but {required_label} "
                 f"allows proceeding; they remain as participants and may rejoin in a later round",
             )
 

--- a/nvflare/app_common/ccwf/swarm_server_ctl.py
+++ b/nvflare/app_common/ccwf/swarm_server_ctl.py
@@ -37,6 +37,7 @@ class SwarmServerController(ServerSideController):
         aggr_clients=None,
         train_clients=None,
         min_clients: int = 0,
+        configure_min_clients: int = 0,
     ):
         result_clients = normalize_config_arg(result_clients)
         starting_client = normalize_config_arg(starting_client)
@@ -60,6 +61,7 @@ class SwarmServerController(ServerSideController):
             progress_timeout=progress_timeout,
             private_p2p=private_p2p,
             min_clients=min_clients,
+            configure_min_clients=configure_min_clients,
         )
         if not train_clients:
             train_clients = []

--- a/tests/unit_test/app_common/ccwf/test_server_ctl_min_clients.py
+++ b/tests/unit_test/app_common/ccwf/test_server_ctl_min_clients.py
@@ -71,7 +71,7 @@ def _make_controller(participating_clients=None, min_clients=0, **kwargs):
     )
 
 
-def _make_stub(clients=None, min_clients=0):
+def _make_stub(clients=None, min_clients=0, configure_min_clients=0):
     """
     Build a ServerSideController instance without calling Controller.__init__.
 
@@ -89,6 +89,7 @@ def _make_stub(clients=None, min_clients=0):
     ctrl = ServerSideController.__new__(ServerSideController)
     ctrl.participating_clients = client_names
     ctrl.min_clients = min_clients
+    ctrl.configure_min_clients = configure_min_clients
     ctrl.client_statuses = {}
     ctrl.workflow_id = "wf-test"
     ctrl.max_status_report_interval = 60.0
@@ -212,7 +213,20 @@ class TestConfigurePhase:
             _add_client_status(ctrl, c, ready=(c in ready_clients))
 
         total_clients = len(ctrl.participating_clients)
-        required = ctrl.min_clients if ctrl.min_clients > 0 else total_clients
+        required = (
+            ctrl.configure_min_clients
+            if ctrl.configure_min_clients > 0
+            else ctrl.min_clients
+            if ctrl.min_clients > 0
+            else total_clients
+        )
+        required_label = (
+            f"configure_min_clients={ctrl.configure_min_clients}"
+            if ctrl.configure_min_clients > 0
+            else f"min_clients={ctrl.min_clients}"
+            if ctrl.min_clients > 0
+            else "all participating clients"
+        )
         failed_clients = [c for c, cs in ctrl.client_statuses.items() if not cs.ready_time]
         configured_count = total_clients - len(failed_clients)
 
@@ -226,7 +240,7 @@ class TestConfigurePhase:
         elif failed_clients:
             ctrl.log_warning(
                 fl_ctx,
-                f"clients {failed_clients} did not configure but min_clients={ctrl.min_clients} allows proceeding",
+                f"clients {failed_clients} did not configure but {required_label} allows proceeding",
             )
 
     def test_all_configured_no_panic(self):
@@ -264,6 +278,21 @@ class TestConfigurePhase:
         ctrl = _make_stub(min_clients=3)
         self._run_configure_check(ctrl, ready_clients=["site-1", "site-2", "site-3"])
         ctrl.system_panic.assert_not_called()
+
+    def test_configure_min_clients_overrides_runtime_min_clients(self):
+        ctrl = _make_stub(min_clients=2, configure_min_clients=4)
+        self._run_configure_check(ctrl, ready_clients=["site-1", "site-2", "site-3"])
+        ctrl.system_panic.assert_called_once()
+        msg = ctrl.system_panic.call_args[0][0]
+        assert "need 4" in msg
+
+    def test_configure_min_clients_allows_stricter_startup_with_runtime_tolerance(self):
+        ctrl = _make_stub(min_clients=2, configure_min_clients=3)
+        self._run_configure_check(ctrl, ready_clients=["site-1", "site-2", "site-3"])
+        ctrl.system_panic.assert_not_called()
+        ctrl.log_warning.assert_called_once()
+        msg = ctrl.log_warning.call_args[0][1]
+        assert "configure_min_clients=3 allows proceeding" in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Separate the CCWF config-phase quorum from runtime `min_clients`

**Problem.** `ServerSideController` / `SwarmServerController` used the runtime `min_clients` as the quorum for the **client-configuration phase**. When `min_clients` is set below the number of participants for fault tolerance (e.g. `min_clients=2` with 3 clients, or the ODELIA 1DC default `min_clients=5` at 7–8 clients), the controller finishes the configure phase after only `min_clients` clients have configured, but still keeps an unconfigured client as `starting_client` and sends it `swarm_start`. That client has no configured global model yet:

```
ValueError: invalid model learnable: expect Model type but got <class 'NoneType'>
→ Aborting current RUN ... failed to start workflow swarm_controller on client <site>
```

**Fix.** Add an optional **`configure_min_clients`** that governs only the configuration phase (default: all participants / backward-compatible with `min_clients` when unset). Runtime `min_clients` continues to govern fault tolerance *after* startup. So all clients configure before any `swarm_start`, while a node can still drop mid-run without aborting.

Verified with the 32 focused ccwf controller unit tests, and end-to-end on a live 3-site swarm (`configure_min_clients=3, min_clients=2`): all clients configure before `swarm_start`, the `NoneType` startup crash no longer occurs, and a post-startup drop is still tolerated.

Pairs with KatherLab/MediSwarm (the app-side patcher/wrapper flags + gitlink bump).
